### PR TITLE
Fix: Correct potential memory issues in arraylist

### DIFF
--- a/src/coll_arraylist.c
+++ b/src/coll_arraylist.c
@@ -96,7 +96,8 @@ int arraylist_apr_new_with_capacity(arraylist **l, apr_pool_t *pool, size_t capa
 	list->array = (void **)apr_pcalloc(pool, sizeof(void *) * list->capacity);
 	if (list->array == NULL)
 	{
-		free(list);
+		// 'list' is allocated from the APR pool, so no need to free it here.
+		// It will be cleaned up when the pool is destroyed.
 		return E_ARRAYLIST_UNABLE_TO_ALLOCATE_ARRAY;
 	}
 
@@ -175,7 +176,11 @@ int arraylist_resize(arraylist *l, size_t max)
 			{
 				return E_ARRAYLIST_UNABLE_TO_ALLOCATE_ARRAY;
 			}
-			memcpy(new_array, l->array, l->capacity * sizeof(void *));
+		// Only copy the valid elements from the old array.
+		// The number of valid elements is l->size, not l->capacity.
+		if (l->array != NULL && l->size > 0) { // Ensure there's something to copy
+		    memcpy(new_array, l->array, l->size * sizeof(void *));
+		}
 			l->array = new_array;
 			l->capacity = new_capacity;
 			// old array need not be freed as it will be removed

--- a/src/coll_arraylist.h
+++ b/src/coll_arraylist.h
@@ -204,11 +204,14 @@ void arraylist_clear(arraylist* l);
 
 /**
 * Deletes the item at location loc of the arraylist.
-* NOTE: Deleted item is not freed, user must free if needed.
+* If a `free_fn` was provided during list creation, the item at `loc`
+* will be freed using that function. Otherwise, the pointer is removed
+* from the list without freeing the underlying item (user remains responsible).
 *
-* @param l the arraylist
-* @param loc location to delete at
-* @return item the deleted item (NULL if unable to delete or value was NULL)
+* @param l the arraylist.
+* @param loc location to delete at.
+* @return 0 on success, or an error code (e.g., E_ARRAYLIST_INDEX_NOT_FOUND) if
+*         the location is invalid. This function does not return the deleted item.
 **/
 int arraylist_delete(arraylist* l, size_t loc);
 


### PR DESCRIPTION
I analyzed the arraylist implementation for potential memory leaks and misuses. The following changes were made:

1.  `src/coll_arraylist.c` (`arraylist_apr_new_with_capacity`): I removed an incorrect call to `free()` on memory allocated from an APR pool. This prevents potential heap corruption when APR is enabled and allocation of the internal array fails.

2.  `src/coll_arraylist.c` (`arraylist_resize`): In the APR-enabled path, I corrected `memcpy` to use the actual number of items (`l->size`) instead of `l->capacity` when copying data to the new array. This prevents reading from uninitialized memory.

3.  `src/coll_arraylist.h` (`arraylist_delete`): I updated the function's documentation comment to accurately reflect its behavior. The item at the specified location *is* freed if a `free_fn` was provided (contradicting the old comment), and the function returns an integer status code, not the deleted item.

I analyzed other functions, and their memory handling was found to be consistent with the library's design, where your provision of an appropriate `free_fn` is critical for items not managed by APR pools directly.